### PR TITLE
Runtime logs in plaintext and bump proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,15 @@
 version: '3'
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.18
-    command: -Xmx8g -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.event-sourced-entity-eventing.number-of-projection-instances=8
+    image: gcr.io/kalix-public/kalix-runtime:1.1.27
     ports:
       - '9000:9000'
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Xmx8g 
+        -Dkalix.proxy.eventing.event-sourced-entity-eventing.number-of-projection-instances=8
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <!-- For Docker setup see https://docs.kalix.io/projects/container-registries.html -->
     <kalixContainerRegistry>kcr.eu-central-1.kalix.io</kalixContainerRegistry>
     <kalixOrganization>lightbend</kalixOrganization>
-    <!--dockerImage>${D}{kalixContainerRegistry}/${D}{kalixOrganization}/${D}{project.artifactId}<dockerImage-->
     <dockerImage>${kalixContainerRegistry}/${kalixOrganization}/${project.artifactId}</dockerImage>
     <dockerTag>${project.version}-${build.timestamp}</dockerTag>
     <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>


### PR DESCRIPTION
Just noticed that logs from proxy were still outputed in JSON, this makes it plaintext. Also, bumps proxy.